### PR TITLE
build: binary for armv6 gnueabihf

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -35,6 +35,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
             use-cross: true
+          - target: arm-unknown-linux-gnueabihf
+            os: ubuntu-22.04
+            use-cross: true
           - target: x86_64-apple-darwin
             os: macos-12
           - target: x86_64-unknown-linux-gnu

--- a/lib/candlex/native.ex
+++ b/lib/candlex/native.ex
@@ -15,9 +15,9 @@ defmodule Candlex.Native do
     version: version,
     nif_versions: ["2.16"],
     targets: [
-      "arm-unknown-linux-gnueabihf",
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabihf",
       "x86_64-apple-darwin",
       "x86_64-unknown-linux-gnu"
     ],

--- a/lib/candlex/native.ex
+++ b/lib/candlex/native.ex
@@ -15,6 +15,7 @@ defmodule Candlex.Native do
     version: version,
     nif_versions: ["2.16"],
     targets: [
+      "arm-unknown-linux-gnueabihf",
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "x86_64-apple-darwin",


### PR DESCRIPTION
hi ! it would be great to use candlex for  small machines where the default nx backend is very very slow. I've been able to easily compile candlex for this target 